### PR TITLE
Betatesting flip order

### DIFF
--- a/pyappss/analysis/baseline.py
+++ b/pyappss/analysis/baseline.py
@@ -370,14 +370,14 @@ class Baseline:
             self.ax.plot(self.vel, self.yfit, linestyle='--', color='black', linewidth='1', label='yfit')
 
             response = input()
-            if response is '':
+            if response == '':
                 if noconfirm:
                     accepted = True
                 else:
                     self.__plot()
                     response = input('Press Enter again to confirm this baseline fit.'
                                      ' Type anything else and hit enter to try again.\n')
-                    if response is '':
+                    if response == '':
                         accepted = True
                     else:
                         self.res = np.asarray(self.smo)
@@ -386,7 +386,7 @@ class Baseline:
                             print('Plotting a ' + titles[order] + ' order fit.')
                         else:
                             print('Plotting a ' + str(order) + 'order fit.')
-            elif int(response) is -1:
+            elif int(response) == -1:
                 accepted = True
             else:
                 order = int(response)

--- a/pyappss/analysis/baseline.py
+++ b/pyappss/analysis/baseline.py
@@ -79,7 +79,10 @@ class Baseline:
         """
         Reads the FITS file and loads the data into the arrays.
         """
-        hdul = Table.read(self.path)
+        #hdul = Table.read(self.path)
+        tmptab = Table.read(self.path)
+        tmpsort = np.argsort(tmptab['VHELIO'])  # checks for spectra format (increasing v or f)
+        hdul = tmptab[tmpsort]  # forces spectra to increase in v
         self.freq = np.array(hdul['FREQUENCY'].value,'d')
         self.vel = np.array(hdul['VHELIO'].value,'d')
         self.spec = np.array(hdul['FLUX'].value,'d')

--- a/pyappss/analysis/measure.py
+++ b/pyappss/analysis/measure.py
@@ -785,6 +785,7 @@ class Measure:
         leftedge = max(leftedge) - 1
         # This throws an error with max, and works correctly with min, so has been modified according.
         rightedge = min(rightedge) + 1
+        print(leftedge,rightedge)
         # rightedge = max(rightedge) + 1
         # Figure out the "peak" locations, i.e. where the spectrum hits a value of peak-rms
         # In the range given by the bases.

--- a/pyappss/analysis/measure.py
+++ b/pyappss/analysis/measure.py
@@ -187,7 +187,9 @@ class Measure:
         """
         Reads the FITS file and loads the data into the arrays.
         """
-        hdul = Table.read(self.path)
+        tmptab = Table.read(self.path)
+        tmpsort = np.argsort(tmptab['VHELIO'])#checks for spectra format (increasing v or f)
+        hdul = tmptab[tmpsort]#forces spectra to increase in v
         self.freq = np.array(hdul['FREQUENCY'].value, 'd')
         self.vel = np.array(hdul['VHELIO'].value, 'd')
         self.spec = np.array(hdul['FLUX'].value, 'd')

--- a/pyappss/analysis/measure.py
+++ b/pyappss/analysis/measure.py
@@ -785,7 +785,7 @@ class Measure:
         leftedge = max(leftedge) - 1
         # This throws an error with max, and works correctly with min, so has been modified according.
         rightedge = min(rightedge) + 1
-        print(leftedge,rightedge)
+        #print(leftedge,rightedge)
         # rightedge = max(rightedge) + 1
         # Figure out the "peak" locations, i.e. where the spectrum hits a value of peak-rms
         # In the range given by the bases.


### PR DESCRIPTION
Added an intermediate step when loading data - sorts the table on VHELIO (so now data array is increasing in vhelio and decreasing in freq). ALFALFA+APPSS are reverse, so our SNe Host spectra may need to get flipped to match.